### PR TITLE
Handle delegated SPE Graph errors

### DIFF
--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeGraphErrorMapper.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeGraphErrorMapper.cs
@@ -1,0 +1,15 @@
+using System.Net;
+
+namespace SpeAuthorizationDemo.Graph;
+
+public static class SpeGraphErrorMapper
+{
+    public static string ToReasonCode(SpeGraphException exception) => exception.StatusCode switch
+    {
+        HttpStatusCode.Forbidden => "container_permission_denied",
+        HttpStatusCode.Unauthorized => "reauthentication_required",
+        HttpStatusCode.TooManyRequests => "graph_temporarily_unavailable",
+        >= HttpStatusCode.InternalServerError => "graph_temporarily_unavailable",
+        _ => "graph_request_failed"
+    };
+}

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Download.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Download.cshtml.cs
@@ -15,7 +15,14 @@ public sealed class DownloadModel(
     {
         var decision = await authorization.AuthorizeAsync(User, HttpContext, BusinessOperation.DownloadFile, cancellationToken);
         if (!decision.IsAllowed) return RedirectToPage("/AccessDenied", new { reason = decision.ReasonCode });
-        var download = await clients.CreateDelegated().DownloadAsync(id, cancellationToken);
-        return File(download.Content, download.ContentType, download.FileName);
+        try
+        {
+            var download = await clients.CreateDelegated().DownloadAsync(id, cancellationToken);
+            return File(download.Content, download.ContentType, download.FileName);
+        }
+        catch (SpeGraphException exception)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = SpeGraphErrorMapper.ToReasonCode(exception) });
+        }
     }
 }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml.cs
@@ -20,7 +20,14 @@ public sealed class IndexModel(
     {
         Decision = await authorization.AuthorizeAsync(User, HttpContext, BusinessOperation.ListFiles, cancellationToken);
         if (!Decision.IsAllowed) return RedirectToPage("/AccessDenied", new { reason = Decision.ReasonCode });
-        Items = await clients.CreateDelegated().ListRootAsync(cancellationToken);
+        try
+        {
+            Items = await clients.CreateDelegated().ListRootAsync(cancellationToken);
+        }
+        catch (SpeGraphException exception)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = SpeGraphErrorMapper.ToReasonCode(exception) });
+        }
         return Page();
     }
 }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Upload.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Upload.cshtml.cs
@@ -35,7 +35,14 @@ public sealed class UploadModel(
         }
 
         await using var stream = Upload.OpenReadStream();
-        await clients.CreateDelegated().UploadSmallFileAsync(Upload.FileName, stream, Upload.Length, cancellationToken);
+        try
+        {
+            await clients.CreateDelegated().UploadSmallFileAsync(Upload.FileName, stream, Upload.Length, cancellationToken);
+        }
+        catch (SpeGraphException exception)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = SpeGraphErrorMapper.ToReasonCode(exception) });
+        }
         return RedirectToPage("/Files/Index", new { testLocation = TestLocation });
     }
 }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Graph/SpeGraphErrorMapperTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Graph/SpeGraphErrorMapperTests.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using SpeAuthorizationDemo.Graph;
+
+namespace SpeAuthorizationDemo.Tests.Graph;
+
+public sealed class SpeGraphErrorMapperTests
+{
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden, "container_permission_denied")]
+    [InlineData(HttpStatusCode.Unauthorized, "reauthentication_required")]
+    [InlineData(HttpStatusCode.TooManyRequests, "graph_temporarily_unavailable")]
+    [InlineData(HttpStatusCode.InternalServerError, "graph_temporarily_unavailable")]
+    [InlineData(HttpStatusCode.BadRequest, "graph_request_failed")]
+    public void ToReasonCode_MapsGraphStatusWithoutExposingDetails(HttpStatusCode status, string expected)
+    {
+        var exception = new SpeGraphException("sensitive upstream detail", status, "request-id");
+
+        Assert.Equal(expected, SpeGraphErrorMapper.ToReasonCode(exception));
+    }
+}


### PR DESCRIPTION
## Summary`n- map delegated Graph 403 responses to container_permission_denied`n- map 401 and transient Graph failures to safe reason codes`n- prevent production /Files failures from surfacing the generic error page`n`n## Verification`n- warning-as-error build passed`n- 50 tests passed, 0 failed`n- updated package deployed to Azure China App Service