### PR TITLE
Add homepage Container access check

### DIFF
--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
@@ -94,30 +94,28 @@ dotnet run --project .\src\SpeAuthorizationDemo\SpeAuthorizationDemo.csproj `
 
 ## 测试步骤
 
-1. Reader 登录，选择“模拟大陆并访问”，验证列表、下载和上传限制。
-2. Writer 登录，选择“模拟大陆并访问”，验证上传。
-3. Reader 或 Writer 选择“模拟境外并验证拒绝”。
-4. Outside 登录并模拟大陆，验证组外用户被拒绝。
-5. DemoAdmin 登录并打开“App-only 对照”。
+1. 用户登录后在主页点击“验证 Container 访问权限”。
+2. 主页先执行 Tenant、Group/角色和后台 IP 白名单等业务检查。
+3. 业务层通过后，以当前用户 delegated 身份尝试读取 Container 根目录。
+4. 页面分别显示“业务层”和“SPE Container”的通过/拒绝状态。
+5. 验证成功时只显示根目录项目数量，不显示文件名。
 
-`US` 测试不是实际美国公网，而是 Development 环境下通过 `testLocation=US` 模拟位置判断。该参数仅在 `Development + localhost + EnableDevelopmentOverride=true` 时生效，Production 会忽略它。
+业务层失败时不会调用 SPE，Container 状态显示“未验证”。原文件列表、上传、下载和 App-only 页面继续保留在导航中。
 
 ## 测试结果
 
 | 场景 | 结果 |
 |---|---|
-| Reader + CN：列表/下载 | 允许 |
-| Reader + CN：上传 | 拒绝：`operation_not_allowed` |
-| Reader/Writer + US | 拒绝：`location_not_allowed` |
-| Writer + CN：上传 | 成功，上传 `writer-test.txt`（63 bytes） |
-| Outside + CN | 拒绝：`group_not_allowed` |
-| DemoAdmin + CN：app-only | 成功，应用身份读取 3 个根目录项目 |
+| Reader/Writer 从白名单 IP 验证 | 业务层通过，Container 可访问，显示文件数量 |
+| Outside 验证 | 业务层拒绝，Container 未验证 |
+| DemoAdmin 无 Container 用户权限 | 业务层通过，Container 无权限 |
+| 非白名单 IP | App Service 或业务层拒绝 |
 
-自动验证：**45 项测试通过，0 失败**；PowerShell 脚本安全检查通过。
+自动验证：**53 项测试通过，0 失败**；PowerShell 脚本安全检查通过。
 
 ## 测试截图
 
-管理员身份和位置模拟入口：
+原始管理员身份诊断截图（历史测试证据）：
 
 ![管理员身份与位置模拟入口](docs/images/admin-identity-summary.png)
 

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml
@@ -5,20 +5,75 @@
 }
 <div class="hero-panel">
     <div class="eyebrow">21VIANET · SHAREPOINT EMBEDDED</div>
-    <h1>业务授权诊断台</h1>
-    <p>验证 Tenant、Entra Group、来源位置和业务角色，再对比 delegated 与 app-only 的 SPE 安全边界。</p>
+    <h1>Container 访问权限验证</h1>
+    <p>验证当前用户是否同时通过业务授权，并具有读取 SharePoint Embedded Container 文件的 delegated 权限。</p>
 </div>
 
 @if (!(User.Identity?.IsAuthenticated ?? false))
 {
-    <div class="card card-body mt-4"><h2 class="h5">尚未登录</h2><p>使用世纪互联 Entra 测试用户登录后开始。</p><a class="btn btn-primary align-self-start" href="/MicrosoftIdentity/Account/SignIn">登录</a></div>
+    <div class="card card-body mt-4">
+        <h2 class="h5">尚未登录</h2>
+        <p>请先使用世纪互联 Entra 用户登录，然后验证 Container 访问权限。</p>
+        <a class="btn btn-primary align-self-start" href="/MicrosoftIdentity/Account/SignIn">登录并验证</a>
+    </div>
 }
 else
 {
-    <div class="row g-4 mt-1">
-        <div class="col-lg-5"><div class="card card-body h-100"><h2 class="h5">已验证身份</h2><dl class="signal-list"><dt>用户</dt><dd>@User.Identity!.Name</dd><dt>Tenant ID</dt><dd><code>@Model.TenantId</code></dd><dt>Object ID</dt><dd><code>@Model.ObjectId</code></dd><dt>Token Groups</dt><dd>@Model.Groups.Count</dd><dt>Group Overage</dt><dd>@Model.HasGroupOverage</dd></dl></div></div>
-        <div class="col-lg-7"><div class="card card-body h-100"><h2 class="h5">本机位置模拟</h2><p class="text-muted">仅在 Development、显式启用且请求来自 localhost 时生效。Production 会忽略该参数。</p><div class="d-flex flex-wrap gap-2"><a class="btn btn-success" asp-page="/Files/Index" asp-route-testLocation="CN">模拟大陆并访问</a><a class="btn btn-outline-danger" asp-page="/Files/Index" asp-route-testLocation="US">模拟境外并验证拒绝</a><a class="btn btn-outline-warning" asp-page="/AppOnly/Index" asp-route-testLocation="CN">App-only 对照</a></div></div></div>
+    <div class="card card-body mt-4 access-check-card">
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <div>
+                <div class="text-muted small">当前用户</div>
+                <div class="fw-semibold">@User.Identity!.Name</div>
+            </div>
+            <form method="post" asp-page-handler="Validate">
+                <button class="btn btn-primary btn-lg" type="submit">验证 Container 访问权限</button>
+            </form>
+        </div>
     </div>
+
+    @if (Model.HasValidationResult)
+    {
+        <div class="validation-result @(Model.FinalAllowed ? "validation-allowed" : "validation-denied") mt-4">
+            <div class="result-icon">@(Model.FinalAllowed ? "✓" : "×")</div>
+            <div>
+                <h2 class="h4 mb-1">@(Model.FinalAllowed ? "当前用户可以访问 Container" : "当前用户不能访问 Container")</h2>
+                @if (Model.FinalAllowed)
+                {
+                    <p class="mb-0">已成功读取根目录，共 @Model.FileCount 个项目。</p>
+                }
+                else
+                {
+                    <p class="mb-0">请展开详细信息查看被拒绝的层级。</p>
+                }
+            </div>
+        </div>
+
+        <div class="row g-3 mt-1">
+            <div class="col-md-6">
+                <div class="status-card">
+                    <span class="status-dot @(Model.BusinessAllowed ? "status-pass" : "status-fail")"></span>
+                    <div><div class="text-muted small">业务层</div><strong>@(Model.BusinessAllowed ? "通过" : "拒绝")</strong></div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="status-card">
+                    <span class="status-dot @(!Model.ContainerChecked ? "status-pending" : Model.ContainerAllowed ? "status-pass" : "status-fail")"></span>
+                    <div><div class="text-muted small">SPE Container</div><strong>@(!Model.ContainerChecked ? "未验证" : Model.ContainerAllowed ? "可访问" : "无权限")</strong></div>
+                </div>
+            </div>
+        </div>
+
+        <details class="card card-body mt-3">
+            <summary class="fw-semibold">详细信息</summary>
+            <dl class="signal-list mt-3 mb-0">
+                <dt>业务角色</dt><dd>@Model.Role</dd>
+                <dt>业务层原因</dt><dd><code>@Model.BusinessReasonCode</code></dd>
+                <dt>Container 原因</dt><dd><code>@Model.ContainerReasonCode</code></dd>
+                <dt>Tenant ID</dt><dd><code>@Model.TenantId</code></dd>
+                <dt>Object ID</dt><dd><code>@Model.ObjectId</code></dd>
+            </dl>
+        </details>
+    }
 }
 
-<div class="boundary-note mt-4"><strong>边界：</strong>业务判断不是 Conditional Access。Delegated 模式仍由 SPE 检查用户 Container 权限；app-only 模式不会。</div>
+<div class="boundary-note mt-4"><strong>验证范围：</strong>主页先执行现有业务授权；仅在业务层通过后，才以当前用户 delegated 身份读取 Container。文件名不会显示在主页。</div>

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
@@ -1,8 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using SpeAuthorizationDemo.Authorization;
+using SpeAuthorizationDemo.Graph;
 
 namespace SpeAuthorizationDemo.Pages;
 
-public sealed class IndexModel : PageModel
+public sealed class IndexModel(
+    IBusinessAuthorizationService authorization,
+    ISpeGraphClientFactory clients) : PageModel
 {
     public string? TenantId => User.FindFirst("tid")?.Value ?? User.FindFirst("http://schemas.microsoft.com/identity/claims/tenantid")?.Value;
     public string? ObjectId => User.FindFirst("oid")?.Value ?? User.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
@@ -11,5 +16,48 @@ public sealed class IndexModel : PageModel
         .Select(claim => claim.Value)
         .ToArray();
     public bool HasGroupOverage => User.HasClaim(claim => claim.Type == "_claim_names" && claim.Value.Contains("groups", StringComparison.Ordinal));
+
+    public bool HasValidationResult { get; private set; }
+    public bool BusinessAllowed { get; private set; }
+    public bool ContainerChecked { get; private set; }
+    public bool ContainerAllowed { get; private set; }
+    public bool FinalAllowed => BusinessAllowed && ContainerAllowed;
+    public int? FileCount { get; private set; }
+    public BusinessRole Role { get; private set; } = BusinessRole.None;
+    public string BusinessReasonCode { get; private set; } = "not_run";
+    public string ContainerReasonCode { get; private set; } = "not_tested";
+
     public void OnGet() { }
+
+    public async Task<IActionResult> OnPostValidateAsync(CancellationToken cancellationToken)
+    {
+        HasValidationResult = true;
+        var decision = await authorization.AuthorizeAsync(
+            User,
+            HttpContext,
+            BusinessOperation.ListFiles,
+            cancellationToken);
+
+        BusinessAllowed = decision.IsAllowed;
+        BusinessReasonCode = decision.ReasonCode;
+        Role = decision.Role;
+        if (!BusinessAllowed)
+            return Page();
+
+        ContainerChecked = true;
+        try
+        {
+            var items = await clients.CreateDelegated().ListRootAsync(cancellationToken);
+            ContainerAllowed = true;
+            ContainerReasonCode = "allowed";
+            FileCount = items.Count;
+        }
+        catch (SpeGraphException exception)
+        {
+            ContainerAllowed = false;
+            ContainerReasonCode = SpeGraphErrorMapper.ToReasonCode(exception);
+        }
+
+        return Page();
+    }
 }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/wwwroot/css/site.css
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/wwwroot/css/site.css
@@ -41,3 +41,12 @@ body { color:var(--ink); background:linear-gradient(180deg,#f7f9fd 0,#fff 360px)
 .signal-list dt { color:var(--muted); font-weight:500; }.signal-list dd { margin:0; overflow-wrap:anywhere; }
 .boundary-note,.empty-state { padding:1rem 1.25rem; border-radius:.8rem; background:#eef3ff; color:#29406f; }
 .access-denied { max-width:720px; margin:5rem auto; text-align:center; padding:3rem; border-radius:1.5rem; background:#fff3f3; border:1px solid #ffd6d6; }
+.access-check-card { border-color:#dce5f8; }
+.validation-result { display:flex; align-items:center; gap:1rem; padding:1.4rem 1.5rem; border-radius:1rem; border:1px solid; }
+.validation-allowed { background:#effaf4; border-color:#b7e4c9; color:#155d36; }
+.validation-denied { background:#fff4f4; border-color:#f3c2c2; color:#8b2525; }
+.result-icon { display:grid; place-items:center; width:2.7rem; height:2.7rem; flex:0 0 2.7rem; border-radius:50%; background:currentColor; color:white; font-size:1.5rem; font-weight:700; }
+.status-card { display:flex; align-items:center; gap:.8rem; padding:1rem 1.2rem; background:white; border:1px solid #e5e9f2; border-radius:.9rem; }
+.status-dot { width:.75rem; height:.75rem; border-radius:50%; flex:0 0 .75rem; }
+.status-pass { background:#1f9d55; }.status-fail { background:#dc3545; }.status-pending { background:#98a2b3; }
+details summary { cursor:pointer; }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SpeAuthorizationDemo.Authorization;
+using SpeAuthorizationDemo.Graph;
+using SpeAuthorizationDemo.Models;
+using SpeAuthorizationDemo.Pages;
+
+namespace SpeAuthorizationDemo.Tests.Pages;
+
+public sealed class IndexModelTests
+{
+    [Fact]
+    public async Task Validate_BusinessDenied_DoesNotCallContainer()
+    {
+        var graph = new FakeGraphClient();
+        var model = CreateModel(
+            new AuthorizationDecision(false, BusinessRole.None, BusinessOperation.ListFiles, "group_not_allowed"),
+            graph);
+
+        await model.OnPostValidateAsync(CancellationToken.None);
+
+        Assert.True(model.HasValidationResult);
+        Assert.False(model.BusinessAllowed);
+        Assert.False(model.ContainerChecked);
+        Assert.False(model.FinalAllowed);
+        Assert.Equal("group_not_allowed", model.BusinessReasonCode);
+        Assert.Equal(0, graph.ListCalls);
+    }
+
+    [Fact]
+    public async Task Validate_BusinessAndContainerAllowed_ShowsOnlyFileCount()
+    {
+        var graph = new FakeGraphClient
+        {
+            Items =
+            [
+                new SpeDriveItem("1", "secret-one.docx", 12, null),
+                new SpeDriveItem("2", "secret-two.pdf", 34, null)
+            ]
+        };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Reader, BusinessOperation.ListFiles, "allowed"),
+            graph);
+
+        await model.OnPostValidateAsync(CancellationToken.None);
+
+        Assert.True(model.BusinessAllowed);
+        Assert.True(model.ContainerChecked);
+        Assert.True(model.ContainerAllowed);
+        Assert.True(model.FinalAllowed);
+        Assert.Equal(2, model.FileCount);
+        Assert.Equal(BusinessRole.Reader, model.Role);
+        Assert.Equal(1, graph.ListCalls);
+    }
+
+    [Fact]
+    public async Task Validate_ContainerForbidden_ShowsContainerPermissionDenied()
+    {
+        var graph = new FakeGraphClient
+        {
+            Failure = new SpeGraphException("upstream detail", HttpStatusCode.Forbidden)
+        };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.DemoAdmin, BusinessOperation.ListFiles, "allowed"),
+            graph);
+
+        await model.OnPostValidateAsync(CancellationToken.None);
+
+        Assert.True(model.BusinessAllowed);
+        Assert.True(model.ContainerChecked);
+        Assert.False(model.ContainerAllowed);
+        Assert.False(model.FinalAllowed);
+        Assert.Equal("container_permission_denied", model.ContainerReasonCode);
+    }
+
+    private static IndexModel CreateModel(AuthorizationDecision decision, FakeGraphClient graph)
+    {
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim("tid", Guid.NewGuid().ToString()),
+                new Claim("oid", Guid.NewGuid().ToString())
+            ], "test"))
+        };
+        return new IndexModel(new FakeAuthorizationService(decision), new FakeGraphClientFactory(graph))
+        {
+            PageContext = new PageContext { HttpContext = context }
+        };
+    }
+
+    private sealed class FakeAuthorizationService(AuthorizationDecision decision) : IBusinessAuthorizationService
+    {
+        public Task<AuthorizationDecision> AuthorizeAsync(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            BusinessOperation operation,
+            CancellationToken cancellationToken) => Task.FromResult(decision);
+    }
+
+    private sealed class FakeGraphClientFactory(FakeGraphClient graph) : ISpeGraphClientFactory
+    {
+        public ISpeGraphClient CreateDelegated() => graph;
+        public ISpeGraphClient CreateAppOnly() => graph;
+    }
+
+    private sealed class FakeGraphClient : ISpeGraphClient
+    {
+        public IReadOnlyList<SpeDriveItem> Items { get; init; } = [];
+        public SpeGraphException? Failure { get; init; }
+        public int ListCalls { get; private set; }
+
+        public Task<IReadOnlyList<SpeDriveItem>> ListRootAsync(CancellationToken cancellationToken)
+        {
+            ListCalls++;
+            if (Failure is not null) throw Failure;
+            return Task.FromResult(Items);
+        }
+
+        public Task<SpeDownload> DownloadAsync(string itemId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SpeDriveItem> UploadSmallFileAsync(
+            string fileName,
+            Stream content,
+            long length,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary`n- replace homepage location simulation controls with a single Container access check`n- show separate business-layer and delegated SPE Container results`n- skip SPE calls when business authorization fails`n- show only root item count, never file names`n- keep existing file and app-only navigation/routes`n`n## Verification`n- warning-as-error build passed`n- 53 tests passed, 0 failed`n- local homepage smoke test passed