### PR TITLE
Challenge stale delegated SPE sessions

### DIFF
--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/GraphGroupMembershipFallback.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/GraphGroupMembershipFallback.cs
@@ -42,6 +42,14 @@ public sealed class GraphGroupMembershipFallback(
                 .ToHashSet();
             return GroupResolutionResult.Success(groups);
         }
+        catch (MicrosoftIdentityWebChallengeUserException exception)
+        {
+            logger.LogInformation(
+                "Delegated token reauthentication is required for user {ObjectId}: {ExceptionType}.",
+                identity.ObjectId,
+                exception.GetType().Name);
+            return GroupResolutionResult.Failure("reauthentication_required");
+        }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
             logger.LogWarning("Group membership fallback failed for user {ObjectId}: {ExceptionType}.",

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SpeAuthorizationDemo.Authorization;
 using SpeAuthorizationDemo.Graph;
@@ -41,6 +43,12 @@ public sealed class IndexModel(
         BusinessAllowed = decision.IsAllowed;
         BusinessReasonCode = decision.ReasonCode;
         Role = decision.Role;
+        if (BusinessReasonCode == "reauthentication_required")
+        {
+            return Challenge(
+                new AuthenticationProperties { RedirectUri = "/" },
+                OpenIdConnectDefaults.AuthenticationScheme);
+        }
         if (!BusinessAllowed)
             return Page();
 

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SpeAuthorizationDemo.Authorization;
 using SpeAuthorizationDemo.Graph;
@@ -73,6 +76,22 @@ public sealed class IndexModelTests
         Assert.False(model.ContainerAllowed);
         Assert.False(model.FinalAllowed);
         Assert.Equal("container_permission_denied", model.ContainerReasonCode);
+    }
+
+    [Fact]
+    public async Task Validate_ReauthenticationRequired_ChallengesOpenIdConnect()
+    {
+        var graph = new FakeGraphClient();
+        var model = CreateModel(
+            new AuthorizationDecision(false, BusinessRole.None, BusinessOperation.ListFiles, "reauthentication_required"),
+            graph);
+
+        var result = await model.OnPostValidateAsync(CancellationToken.None);
+
+        var challenge = Assert.IsType<ChallengeResult>(result);
+        Assert.Contains(OpenIdConnectDefaults.AuthenticationScheme, challenge.AuthenticationSchemes);
+        Assert.Equal("/", challenge.Properties?.RedirectUri);
+        Assert.Equal(0, graph.ListCalls);
     }
 
     private static IndexModel CreateModel(AuthorizationDecision decision, FakeGraphClient graph)


### PR DESCRIPTION
## Summary`n- detect Microsoft Identity delegated-token cache misses after App Service restarts`n- return reauthentication_required instead of group_fallback_failed`n- automatically challenge OpenID Connect from the homepage`n- never call SPE while reauthentication is required`n`n## Verification`n- warning-as-error build passed`n- 54 tests passed, 0 failed`n- production logs confirmed MsalUiRequiredException after restart