### PR TITLE
Add guarded SPE file deletion for Writer and DemoAdmin

### DIFF
--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
@@ -761,7 +761,21 @@ Container: container_permission_denied
 
 > 当前规则使用 `/32`，只代表指定公网出口，不代表“中国内地全部 IP”。如需“所有内地允许、香港拒绝”，应配置并维护 GeoLite2 Country 数据库，允许 `CN`、拒绝 `HK`；固定办公/VPN 出口 CIDR 更可靠。
 
-## 4.7 自动测试
+## 4.7 Writer / DemoAdmin 删除文件
+
+1. 使用 Writer 或 DemoAdmin 业务角色进入 **Delegated 文件**页；
+2. 文件行显示红色“删除”按钮，Reader 不显示该按钮；
+3. 点击删除并在浏览器确认框中确认；
+4. 后端重新执行 `DeleteFile` 业务授权；
+5. 后端重新读取当前根目录，只接受列表内的文件 ID，拒绝任意或过期 ID；
+6. 后端读取最新项目元数据，文件夹会被拒绝；
+7. DELETE 携带当前 `eTag` 的 `If-Match` 条件；检查后文件若发生变化，Graph 会拒绝删除；
+8. 文件通过 Microsoft Graph DELETE 移入 Container 回收站；
+9. 成功后返回列表并显示“文件已移入回收站”。
+
+即使 Reader 手工构造 POST，后端也会返回 `operation_not_allowed`。DemoAdmin 的业务角色允许删除，但仍必须具备 Container 原生 delegated 权限；否则返回 `container_permission_denied`。本 Demo 不提供永久删除。
+
+## 4.8 自动测试
 
 ```powershell
 dotnet build .\SPEBusinessAuthorizationDemo.sln `
@@ -775,7 +789,7 @@ dotnet test .\SPEBusinessAuthorizationDemo.sln `
 当前结果：
 
 ```text
-54 tests passed
+66 tests passed
 0 tests failed
 ```
 
@@ -790,6 +804,9 @@ dotnet test .\SPEBusinessAuthorizationDemo.sln `
 | `group_not_allowed` | 用户不属于 Reader/Writer/Admin Group |
 | `location_not_allowed` | 公网 IP 未命中应用层白名单 |
 | `operation_not_allowed` | 业务角色不允许当前操作 |
+| `folder_delete_not_allowed` | 删除目标是文件夹，本 Demo 只允许删除文件 |
+| `delete_target_not_allowed` | 删除目标不在当前根目录列表中，或 ID 已过期 |
+| `delete_precondition_failed` | 无法取得用于并发保护的文件 `eTag` |
 | `not_tested` | 业务层失败，因此没有调用 SPE |
 | `container_permission_denied` | 业务层通过，但用户没有 Container delegated 权限 |
 | `reauthentication_required` | App 重启后 Token Cache 失效，需要重新登录 |

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/AuthorizationEngine.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/AuthorizationEngine.cs
@@ -6,7 +6,7 @@ using SpeAuthorizationDemo.Location;
 namespace SpeAuthorizationDemo.Authorization;
 
 public enum BusinessRole { None = 0, Reader = 1, Writer = 2, DemoAdmin = 3 }
-public enum BusinessOperation { ListFiles, DownloadFile, UploadFile, RunAppOnlyComparison }
+public enum BusinessOperation { ListFiles, DownloadFile, UploadFile, DeleteFile, RunAppOnlyComparison }
 
 public sealed record AuthorizationDecision(
     bool IsAllowed,
@@ -42,7 +42,7 @@ public sealed class AuthorizationEngine
         var allowed = operation switch
         {
             BusinessOperation.ListFiles or BusinessOperation.DownloadFile => role >= BusinessRole.Reader,
-            BusinessOperation.UploadFile => role >= BusinessRole.Writer,
+            BusinessOperation.UploadFile or BusinessOperation.DeleteFile => role >= BusinessRole.Writer,
             BusinessOperation.RunAppOnlyComparison => role >= BusinessRole.DemoAdmin,
             _ => false
         };

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeDeletePreconditionException.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeDeletePreconditionException.cs
@@ -1,0 +1,4 @@
+namespace SpeAuthorizationDemo.Graph;
+
+public sealed class SpeDeletePreconditionException()
+    : InvalidOperationException("The file cannot be deleted because its concurrency metadata is unavailable.");

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeFolderDeleteNotAllowedException.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeFolderDeleteNotAllowedException.cs
@@ -1,0 +1,4 @@
+namespace SpeAuthorizationDemo.Graph;
+
+public sealed class SpeFolderDeleteNotAllowedException()
+    : InvalidOperationException("Folder deletion is not allowed by this application.");

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeGraphClient.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Graph/SpeGraphClient.cs
@@ -11,6 +11,7 @@ public interface ISpeGraphClient
     Task<IReadOnlyList<SpeDriveItem>> ListRootAsync(CancellationToken cancellationToken);
     Task<SpeDownload> DownloadAsync(string itemId, CancellationToken cancellationToken);
     Task<SpeDriveItem> UploadSmallFileAsync(string fileName, Stream content, long length, CancellationToken cancellationToken);
+    Task DeleteFileAsync(string itemId, CancellationToken cancellationToken);
 }
 
 public sealed class SpeGraphClient(
@@ -80,6 +81,31 @@ public sealed class SpeGraphClient(
         return ParseItem(document.RootElement);
     }
 
+    public async Task DeleteFileAsync(string itemId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(itemId))
+            throw new ArgumentException("Item ID is required.", nameof(itemId));
+
+        var itemPath = $"items/{Uri.EscapeDataString(itemId)}";
+        using var metadataResponse = await SendReadWithRetryAsync(
+            () => CreateRequestAsync(HttpMethod.Get, itemPath, cancellationToken),
+            HttpCompletionOption.ResponseContentRead,
+            cancellationToken);
+        await EnsureSuccessAsync(metadataResponse, cancellationToken);
+        await using var metadataStream = await metadataResponse.Content.ReadAsStreamAsync(cancellationToken);
+        using var metadata = await JsonDocument.ParseAsync(metadataStream, cancellationToken: cancellationToken);
+        if (metadata.RootElement.TryGetProperty("folder", out _))
+            throw new SpeFolderDeleteNotAllowedException();
+        if (!metadata.RootElement.TryGetProperty("eTag", out var eTagElement) ||
+            string.IsNullOrWhiteSpace(eTagElement.GetString()))
+            throw new SpeDeletePreconditionException();
+
+        using var deleteRequest = await CreateRequestAsync(HttpMethod.Delete, itemPath, cancellationToken);
+        deleteRequest.Headers.IfMatch.Add(EntityTagHeaderValue.Parse(eTagElement.GetString()!));
+        using var deleteResponse = await httpClient.SendAsync(deleteRequest, cancellationToken);
+        await EnsureSuccessAsync(deleteResponse, cancellationToken);
+    }
+
     private async Task<HttpRequestMessage> CreateRequestAsync(HttpMethod method, string relativePath, CancellationToken cancellationToken)
     {
         var containerId = Uri.EscapeDataString(spe.ContainerId);
@@ -114,7 +140,8 @@ public sealed class SpeGraphClient(
         item.GetProperty("id").GetString() ?? "",
         item.GetProperty("name").GetString() ?? "",
         item.TryGetProperty("size", out var size) ? size.GetInt64() : 0,
-        item.TryGetProperty("webUrl", out var webUrl) ? webUrl.GetString() : null);
+        item.TryGetProperty("webUrl", out var webUrl) ? webUrl.GetString() : null,
+        item.TryGetProperty("folder", out _));
 
     private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Models/SpeDriveItem.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Models/SpeDriveItem.cs
@@ -1,4 +1,4 @@
 namespace SpeAuthorizationDemo.Models;
 
-public sealed record SpeDriveItem(string Id, string Name, long Size, string? WebUrl);
+public sealed record SpeDriveItem(string Id, string Name, long Size, string? WebUrl, bool IsFolder = false);
 public sealed record SpeDownload(Stream Content, string FileName, string ContentType);

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml
@@ -14,6 +14,10 @@
 {
     <div class="alert alert-success">业务角色：<strong>@Model.Decision.Role</strong>；授权结果：@Model.Decision.ReasonCode</div>
 }
+@if (!string.IsNullOrWhiteSpace(Model.StatusMessage))
+{
+    <div class="alert alert-info">@Model.StatusMessage</div>
+}
 <table class="table table-hover align-middle">
     <thead><tr><th>名称</th><th>大小</th><th></th></tr></thead>
     <tbody>
@@ -22,7 +26,18 @@
         <tr>
             <td>@item.Name</td>
             <td>@item.Size.ToString("N0") bytes</td>
-            <td class="text-end"><a class="btn btn-sm btn-outline-secondary" asp-page="/Files/Download" asp-route-id="@item.Id" asp-route-testLocation="@Model.TestLocation">下载</a></td>
+            <td class="text-end">
+                <div class="d-inline-flex gap-2">
+                    <a class="btn btn-sm btn-outline-secondary" asp-page="/Files/Download" asp-route-id="@item.Id" asp-route-testLocation="@Model.TestLocation">下载</a>
+                    @if (Model.CanDelete && !item.IsFolder)
+                    {
+                        <form method="post" asp-page-handler="Delete" asp-route-testLocation="@Model.TestLocation" class="d-inline" onsubmit="return confirm('确定将此文件移入回收站吗？');">
+                            <input type="hidden" name="itemId" value="@item.Id" />
+                            <button type="submit" class="btn btn-sm btn-outline-danger">删除</button>
+                        </form>
+                    }
+                </div>
+            </td>
         </tr>
     }
     </tbody>

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Files/Index.cshtml.cs
@@ -14,6 +14,8 @@ public sealed class IndexModel(
 {
     public IReadOnlyList<SpeDriveItem> Items { get; private set; } = [];
     public AuthorizationDecision? Decision { get; private set; }
+    public bool CanDelete => Decision?.Role >= BusinessRole.Writer;
+    [TempData] public string? StatusMessage { get; set; }
     [BindProperty(SupportsGet = true)] public string? TestLocation { get; set; }
 
     public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken)
@@ -29,5 +31,46 @@ public sealed class IndexModel(
             return RedirectToPage("/AccessDenied", new { reason = SpeGraphErrorMapper.ToReasonCode(exception) });
         }
         return Page();
+    }
+
+    public async Task<IActionResult> OnPostDeleteAsync(
+        string itemId,
+        CancellationToken cancellationToken)
+    {
+        var decision = await authorization.AuthorizeAsync(
+            User,
+            HttpContext,
+            BusinessOperation.DeleteFile,
+            cancellationToken);
+        if (!decision.IsAllowed)
+            return RedirectToPage("/AccessDenied", new { reason = decision.ReasonCode });
+
+        try
+        {
+            var client = clients.CreateDelegated();
+            var currentItems = await client.ListRootAsync(cancellationToken);
+            var target = currentItems.SingleOrDefault(item => item.Id == itemId);
+            if (target is null)
+                return RedirectToPage("/AccessDenied", new { reason = "delete_target_not_allowed" });
+            if (target.IsFolder)
+                return RedirectToPage("/AccessDenied", new { reason = "folder_delete_not_allowed" });
+
+            await client.DeleteFileAsync(itemId, cancellationToken);
+        }
+        catch (SpeFolderDeleteNotAllowedException)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = "folder_delete_not_allowed" });
+        }
+        catch (SpeDeletePreconditionException)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = "delete_precondition_failed" });
+        }
+        catch (SpeGraphException exception)
+        {
+            return RedirectToPage("/AccessDenied", new { reason = SpeGraphErrorMapper.ToReasonCode(exception) });
+        }
+
+        StatusMessage = "文件已移入回收站。";
+        return RedirectToPage("/Files/Index", new { testLocation = TestLocation });
     }
 }

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Authorization/AuthorizationEngineTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Authorization/AuthorizationEngineTests.cs
@@ -19,6 +19,9 @@ public sealed class AuthorizationEngineTests
     [InlineData(BusinessRole.Reader, BusinessOperation.DownloadFile, true)]
     [InlineData(BusinessRole.Reader, BusinessOperation.UploadFile, false)]
     [InlineData(BusinessRole.Writer, BusinessOperation.UploadFile, true)]
+    [InlineData(BusinessRole.Reader, BusinessOperation.DeleteFile, false)]
+    [InlineData(BusinessRole.Writer, BusinessOperation.DeleteFile, true)]
+    [InlineData(BusinessRole.DemoAdmin, BusinessOperation.DeleteFile, true)]
     [InlineData(BusinessRole.Writer, BusinessOperation.RunAppOnlyComparison, false)]
     [InlineData(BusinessRole.DemoAdmin, BusinessOperation.RunAppOnlyComparison, true)]
     public void Decide_EnforcesRoleOperationMatrix(

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Graph/SpeGraphClientTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Graph/SpeGraphClientTests.cs
@@ -115,6 +115,80 @@ public sealed class SpeGraphClientTests
         Assert.Contains("claims=", exception.ClaimsChallenge);
     }
 
+    [Fact]
+    public async Task DeleteFileAsync_VerifiesItemIsFileThenDeletesToRecycleBin()
+    {
+        var requests = new List<(HttpMethod Method, string Url)>();
+        var handler = new RecordingHandler(request =>
+        {
+            requests.Add((request.Method, request.RequestUri!.AbsoluteUri));
+            return request.Method == HttpMethod.Get
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"id\":\"item-1\",\"name\":\"file.txt\",\"size\":12,\"eTag\":\"\\\"etag-1\\\"\"}", Encoding.UTF8, "application/json")
+                }
+                : new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await Create(handler).DeleteFileAsync("item-1", CancellationToken.None);
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal(HttpMethod.Get, requests[0].Method);
+        Assert.Equal("https://microsoftgraph.chinacloudapi.cn/v1.0/drives/b%21configured/items/item-1", requests[0].Url);
+        Assert.Equal(HttpMethod.Delete, requests[1].Method);
+        Assert.Equal(requests[0].Url, requests[1].Url);
+        Assert.Equal("\"etag-1\"", handler.LastRequest!.Headers.IfMatch.Single().Tag);
+    }
+
+    [Fact]
+    public async Task DeleteFileAsync_RejectsFolderBeforeDelete()
+    {
+        var requests = new List<HttpMethod>();
+        var handler = new RecordingHandler(request =>
+        {
+            requests.Add(request.Method);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":\"folder-1\",\"name\":\"Folder\",\"folder\":{\"childCount\":1}}", Encoding.UTF8, "application/json")
+            };
+        });
+
+        await Assert.ThrowsAsync<SpeFolderDeleteNotAllowedException>(() =>
+            Create(handler).DeleteFileAsync("folder-1", CancellationToken.None));
+
+        Assert.Equal([HttpMethod.Get], requests);
+    }
+
+    [Fact]
+    public async Task DeleteFileAsync_RejectsMissingItemIdBeforeHttpRequest()
+    {
+        var handler = new RecordingHandler(_ => throw new InvalidOperationException("HTTP must not be called"));
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            Create(handler).DeleteFileAsync("", CancellationToken.None));
+
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task DeleteFileAsync_RejectsMissingEtagBeforeDelete()
+    {
+        var requests = new List<HttpMethod>();
+        var handler = new RecordingHandler(request =>
+        {
+            requests.Add(request.Method);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"id\":\"item-1\",\"name\":\"file.txt\"}", Encoding.UTF8, "application/json")
+            };
+        });
+
+        await Assert.ThrowsAsync<SpeDeletePreconditionException>(() =>
+            Create(handler).DeleteFileAsync("item-1", CancellationToken.None));
+
+        Assert.Equal([HttpMethod.Get], requests);
+    }
+
     private static SpeGraphClient Create(HttpMessageHandler handler) => new(
         new HttpClient(handler),
         new StaticTokenProvider(),

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/FilesIndexDeleteTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/FilesIndexDeleteTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SpeAuthorizationDemo.Authorization;
+using SpeAuthorizationDemo.Graph;
+using SpeAuthorizationDemo.Models;
+using SpeAuthorizationDemo.Pages.Files;
+
+namespace SpeAuthorizationDemo.Tests.Pages;
+
+public sealed class FilesIndexDeleteTests
+{
+    [Fact]
+    public async Task Delete_ReaderRole_IsRejectedWithoutGraphCall()
+    {
+        var graph = new FakeGraphClient();
+        var model = CreateModel(
+            new AuthorizationDecision(false, BusinessRole.Reader, BusinessOperation.DeleteFile, "operation_not_allowed"),
+            graph);
+
+        var result = await model.OnPostDeleteAsync("item-1", CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("/AccessDenied", redirect.PageName);
+        Assert.Equal("operation_not_allowed", redirect.RouteValues!["reason"]);
+        Assert.Equal(0, graph.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task Delete_WriterRole_DeletesAndReturnsSuccessMessage()
+    {
+        var graph = new FakeGraphClient();
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Writer, BusinessOperation.DeleteFile, "allowed"),
+            graph);
+        model.TestLocation = "China";
+
+        var result = await model.OnPostDeleteAsync("item-1", CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("/Files/Index", redirect.PageName);
+        Assert.Equal("item-1", graph.DeletedItemId);
+        Assert.Equal("文件已移入回收站。", model.StatusMessage);
+        Assert.Equal("China", redirect.RouteValues!["testLocation"]);
+    }
+
+    [Fact]
+    public async Task Delete_Folder_IsRejected()
+    {
+        var graph = new FakeGraphClient
+        {
+            Items = [new SpeDriveItem("folder-1", "Folder", 0, null, true)]
+        };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Writer, BusinessOperation.DeleteFile, "allowed"),
+            graph);
+
+        var result = await model.OnPostDeleteAsync("folder-1", CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("folder_delete_not_allowed", redirect.RouteValues!["reason"]);
+        Assert.Equal(0, graph.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task Delete_GraphForbidden_UsesSafeReasonCode()
+    {
+        var graph = new FakeGraphClient
+        {
+            GraphFailure = new SpeGraphException("upstream", HttpStatusCode.Forbidden)
+        };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Writer, BusinessOperation.DeleteFile, "allowed"),
+            graph);
+
+        var result = await model.OnPostDeleteAsync("item-1", CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("container_permission_denied", redirect.RouteValues!["reason"]);
+    }
+
+    [Fact]
+    public async Task Delete_ItemNotInCurrentRootList_IsRejectedBeforeDelete()
+    {
+        var graph = new FakeGraphClient();
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Writer, BusinessOperation.DeleteFile, "allowed"),
+            graph);
+
+        var result = await model.OnPostDeleteAsync("arbitrary-item", CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("delete_target_not_allowed", redirect.RouteValues!["reason"]);
+        Assert.Equal(0, graph.DeleteCalls);
+    }
+
+    private static IndexModel CreateModel(AuthorizationDecision decision, FakeGraphClient graph)
+    {
+        var context = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity([new Claim("oid", Guid.NewGuid().ToString())], "test"))
+        };
+        return new IndexModel(new FakeAuthorizationService(decision), new FakeGraphClientFactory(graph))
+        {
+            PageContext = new PageContext { HttpContext = context }
+        };
+    }
+
+    private sealed class FakeAuthorizationService(AuthorizationDecision decision) : IBusinessAuthorizationService
+    {
+        public Task<AuthorizationDecision> AuthorizeAsync(
+            ClaimsPrincipal user,
+            HttpContext httpContext,
+            BusinessOperation operation,
+            CancellationToken cancellationToken) => Task.FromResult(decision);
+    }
+
+    private sealed class FakeGraphClientFactory(FakeGraphClient graph) : ISpeGraphClientFactory
+    {
+        public ISpeGraphClient CreateDelegated() => graph;
+        public ISpeGraphClient CreateAppOnly() => graph;
+    }
+
+    private sealed class FakeGraphClient : ISpeGraphClient
+    {
+        public IReadOnlyList<SpeDriveItem> Items { get; init; } =
+            [new SpeDriveItem("item-1", "file.txt", 12, null)];
+        public SpeGraphException? GraphFailure { get; init; }
+        public int DeleteCalls { get; private set; }
+        public string? DeletedItemId { get; private set; }
+
+        public Task DeleteFileAsync(string itemId, CancellationToken cancellationToken)
+        {
+            DeleteCalls++;
+            if (GraphFailure is not null) throw GraphFailure;
+            DeletedItemId = itemId;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<SpeDriveItem>> ListRootAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(Items);
+
+        public Task<SpeDownload> DownloadAsync(string itemId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SpeDriveItem> UploadSmallFileAsync(string fileName, Stream content, long length, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+}

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
@@ -146,5 +146,8 @@ public sealed class IndexModelTests
             Stream content,
             long length,
             CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task DeleteFileAsync(string itemId, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary`n- add server-authorized delete buttons for Writer and DemoAdmin`n- revalidate root-list membership and reject folders`n- protect Graph DELETE with current eTag via If-Match`n- add safe error mappings and regression coverage`n`n## Verification`n- dotnet build --no-restore -warnaserror`n- dotnet test --no-build (66 passed)