### PR TITLE
Fix delegated token reauthentication after App Service restart

### DIFF
--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/README.md
@@ -529,7 +529,7 @@ request.Content = JsonContent.Create(new
 });
 ```
 
-若 App Service 重启导致内存 Token Cache 清空，应用返回 `reauthentication_required` 并自动重新触发 OIDC 登录，不把它误报为 Group 无权限。
+若 App Service 重启导致内存 Token Cache 清空，无论是在 Group fallback 还是后续 Container delegated token 获取阶段，应用都会自动重新触发 OIDC 登录，不显示通用错误页，也不把它误报为 Group 无权限。
 
 ## 3.4 业务授权
 
@@ -789,7 +789,7 @@ dotnet test .\SPEBusinessAuthorizationDemo.sln `
 当前结果：
 
 ```text
-66 tests passed
+70 tests passed
 0 tests failed
 ```
 

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/GraphGroupMembershipFallback.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Authorization/GraphGroupMembershipFallback.cs
@@ -43,6 +43,7 @@ public sealed class GraphGroupMembershipFallback(
             return GroupResolutionResult.Success(groups);
         }
         catch (MicrosoftIdentityWebChallengeUserException exception)
+            when (exception.MsalUiRequiredException.ErrorCode == "user_null")
         {
             logger.LogInformation(
                 "Delegated token reauthentication is required for user {ObjectId}: {ExceptionType}.",
@@ -50,7 +51,7 @@ public sealed class GraphGroupMembershipFallback(
                 exception.GetType().Name);
             return GroupResolutionResult.Failure("reauthentication_required");
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (exception is not OperationCanceledException and not MicrosoftIdentityWebChallengeUserException)
         {
             logger.LogWarning("Group membership fallback failed for user {ObjectId}: {ExceptionType}.",
                 identity.ObjectId, exception.GetType().Name);

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/src/SpeAuthorizationDemo/Pages/Index.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Identity.Web;
 using SpeAuthorizationDemo.Authorization;
 using SpeAuthorizationDemo.Graph;
 
@@ -64,6 +65,13 @@ public sealed class IndexModel(
         {
             ContainerAllowed = false;
             ContainerReasonCode = SpeGraphErrorMapper.ToReasonCode(exception);
+        }
+        catch (MicrosoftIdentityWebChallengeUserException exception)
+            when (exception.MsalUiRequiredException.ErrorCode == "user_null")
+        {
+            return Challenge(
+                new AuthenticationProperties { RedirectUri = "/" },
+                OpenIdConnectDefaults.AuthenticationScheme);
         }
 
         return Page();

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Authorization/GraphGroupMembershipFallbackTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Authorization/GraphGroupMembershipFallbackTests.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
+using SpeAuthorizationDemo.Authentication;
+using SpeAuthorizationDemo.Authorization;
+
+namespace SpeAuthorizationDemo.Tests.Authorization;
+
+public sealed class GraphGroupMembershipFallbackTests
+{
+    [Fact]
+    public async Task Resolve_TokenCacheMissing_ReturnsReauthenticationRequired()
+    {
+        var exception = CreateChallenge("user_null");
+        var fallback = CreateFallback(exception);
+
+        var result = await fallback.ResolveAsync(CreateIdentity(), RelevantGroups(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("reauthentication_required", result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task Resolve_ConditionalAccessChallenge_IsPreserved()
+    {
+        var expected = CreateChallenge("claims_challenge");
+        var fallback = CreateFallback(expected);
+
+        var actual = await Assert.ThrowsAsync<MicrosoftIdentityWebChallengeUserException>(() =>
+            fallback.ResolveAsync(CreateIdentity(), RelevantGroups(), CancellationToken.None));
+
+        Assert.Same(expected, actual);
+    }
+
+    private static GraphGroupMembershipFallback CreateFallback(Exception exception)
+    {
+        var tokenAcquisition = DispatchProxy.Create<ITokenAcquisition, ThrowingTokenAcquisitionProxy>();
+        ((ThrowingTokenAcquisitionProxy)(object)tokenAcquisition).Exception = exception;
+        return new GraphGroupMembershipFallback(
+            new HttpClient(),
+            tokenAcquisition,
+            NullLogger<GraphGroupMembershipFallback>.Instance);
+    }
+
+    private static MicrosoftIdentityWebChallengeUserException CreateChallenge(string errorCode) =>
+        new(
+            new MsalUiRequiredException(errorCode, "Interactive authentication is required."),
+            ["https://microsoftgraph.chinacloudapi.cn/GroupMember.Read.All"],
+            null);
+
+    private static UserIdentity CreateIdentity() =>
+        new(Guid.NewGuid(), Guid.NewGuid(), "Test User", new HashSet<Guid>(), true);
+
+    private static IReadOnlySet<Guid> RelevantGroups() =>
+        new HashSet<Guid> { Guid.NewGuid() };
+
+    public class ThrowingTokenAcquisitionProxy : DispatchProxy
+    {
+        public Exception Exception { get; set; } = new InvalidOperationException();
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) => throw Exception;
+    }
+}

--- a/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
+++ b/SharePoint Embedded aka SPE/SPEBusinessAuthorizationDemo/tests/SpeAuthorizationDemo.Tests/Pages/IndexModelTests.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
 using SpeAuthorizationDemo.Authorization;
 using SpeAuthorizationDemo.Graph;
 using SpeAuthorizationDemo.Models;
@@ -94,6 +96,46 @@ public sealed class IndexModelTests
         Assert.Equal(0, graph.ListCalls);
     }
 
+    [Fact]
+    public async Task Validate_DelegatedTokenCacheMissing_ChallengesOpenIdConnect()
+    {
+        var graph = new FakeGraphClient
+        {
+            Failure = new MicrosoftIdentityWebChallengeUserException(
+                new MsalUiRequiredException("user_null", "No cached account."),
+                ["https://microsoftgraph.chinacloudapi.cn/FileStorageContainer.Selected"],
+                null)
+        };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Reader, BusinessOperation.ListFiles, "allowed"),
+            graph);
+
+        var result = await model.OnPostValidateAsync(CancellationToken.None);
+
+        var challenge = Assert.IsType<ChallengeResult>(result);
+        Assert.Contains(OpenIdConnectDefaults.AuthenticationScheme, challenge.AuthenticationSchemes);
+        Assert.Equal("/", challenge.Properties?.RedirectUri);
+        Assert.Equal(1, graph.ListCalls);
+    }
+
+    [Fact]
+    public async Task Validate_ConditionalAccessChallenge_IsPreserved()
+    {
+        var expected = new MicrosoftIdentityWebChallengeUserException(
+            new MsalUiRequiredException("claims_challenge", "Additional claims are required."),
+            ["https://microsoftgraph.chinacloudapi.cn/FileStorageContainer.Selected"],
+            null);
+        var graph = new FakeGraphClient { Failure = expected };
+        var model = CreateModel(
+            new AuthorizationDecision(true, BusinessRole.Reader, BusinessOperation.ListFiles, "allowed"),
+            graph);
+
+        var actual = await Assert.ThrowsAsync<MicrosoftIdentityWebChallengeUserException>(() =>
+            model.OnPostValidateAsync(CancellationToken.None));
+
+        Assert.Same(expected, actual);
+    }
+
     private static IndexModel CreateModel(AuthorizationDecision decision, FakeGraphClient graph)
     {
         var context = new DefaultHttpContext
@@ -128,7 +170,7 @@ public sealed class IndexModelTests
     private sealed class FakeGraphClient : ISpeGraphClient
     {
         public IReadOnlyList<SpeDriveItem> Items { get; init; } = [];
-        public SpeGraphException? Failure { get; init; }
+        public Exception? Failure { get; init; }
         public int ListCalls { get; private set; }
 
         public Task<IReadOnlyList<SpeDriveItem>> ListRootAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Root cause`nAfter App Service restart, the in-memory MSAL cache is empty. Home-page Container validation raised MicrosoftIdentityWebChallengeUserException (`user_null`) and reached the generic production error page.`n`n## Fix`n- challenge OIDC only for the `user_null` cache-loss condition`n- preserve Conditional Access and other Microsoft Identity challenges`n- apply the same narrowing to group-overage fallback`n- add focused regression coverage`n`n## Verification`n- warning-as-error build passed`n- 70 tests passed